### PR TITLE
Changed service from Ethereal to Gmail 

### DIFF
--- a/src/utils/sendEmail.js
+++ b/src/utils/sendEmail.js
@@ -68,11 +68,10 @@ const validateEmailParams = (to, subject, html) => {
 const createTransporter = async () => {
   try {
     const transporter = nodemailer.createTransport({
-      host: 'smtp.ethereal.email',
-      port: 587,
+     service: 'Gmail',
       auth: {
-        user: process.env.EMAIL_USER,
-        pass: process.env.EMAIL_PASS
+        user: process.env.EMAIL_USER, // gmail address
+        pass: process.env.EMAIL_PASS // gmail app password
       }
     });
 
@@ -109,7 +108,7 @@ const sendEmail = async (to, subject, html) => {
 
     // Attempt to send email
     const info = await transporter.sendMail({
-      from: 'pietro77@ethereal.email', // Using Ethereal email address
+      from: 'stephya166@gmail.com', // Using Gmail email address
       to,
       subject,
       html,


### PR DESCRIPTION
changed service from Ethereal Mail to Gmail, will need to create a gmail app password and put it under EMAIL_PASS="" along with gmail email address as EMAIL_USER="" and 
CLIENT_URL=http://localhost:3000 in env. 

Testing as follows: 

<img width="614" alt="Screenshot 2025-05-11 at 2 13 56 AM" src="https://github.com/user-attachments/assets/8abada21-d2dc-4b8b-986a-397cb0de6d9f" />

this sends email to gmail account with token, copy token and place inside of URL in postman

<img width="612" alt="Screenshot 2025-05-11 at 2 14 27 AM" src="https://github.com/user-attachments/assets/10816313-f82d-4c99-bde8-94accc7ed690" />

Password has been reset. 


